### PR TITLE
Keep working for packages not ported in rocqPackages yet

### DIFF
--- a/config-parser-1.0.0/default.nix
+++ b/config-parser-1.0.0/default.nix
@@ -48,7 +48,7 @@ in with config; let
       let ppaths = bundle-ppaths i; in
       foldl recursiveUpdate {} (
         [ (mk-main ppaths.shell config.shell-attribute) ]
-        ++ optional (i ? rocqPackages) (mk-main ppaths.rocq config.attribute)
+        ++ optional ((i ? rocqPackages) && !(config.no-rocq-yet)) (mk-main ppaths.rocq config.attribute)
         ++ optional (i ? coqPackages) (mk-main ppaths.coq config.coq-attribute)
         ++ [
              i
@@ -64,7 +64,7 @@ in with config; let
   mk-instance = bundleName: bundle: let
     overlays = import ./overlays.nix
       { inherit lib overlays-dir rocq-overlays-dir coq-overlays-dir ocaml-overlays-dir bundle;
-        inherit (config) attribute coq-attribute pname shell-attribute shell-pname src; };
+        inherit (config) attribute coq-attribute no-rocq-yet pname shell-attribute shell-pname src; };
 
     pkgs = import config.nixpkgs { inherit overlays; };
 

--- a/config-parser-1.0.0/normalize.nix
+++ b/config-parser-1.0.0/normalize.nix
@@ -31,6 +31,7 @@ in rec {
   attribute = config.attribute or "template";
   coq-attribute = config.coq-attribute or attribute;
   shell-attribute = config.shell-attribute or attribute;
+  no-rocq-yet = config.no-rocq-yet or false;
   nixpkgs = config.nixpkgs or initial.nixpkgs;
   pname = config.pname or attribute;
   shell-pname = config.shell-pname or pname;

--- a/config-parser-1.0.0/overlays.nix
+++ b/config-parser-1.0.0/overlays.nix
@@ -1,5 +1,5 @@
 { overlays-dir, lib, rocq-overlays-dir, coq-overlays-dir, ocaml-overlays-dir, bundle,
-  attribute, coq-attribute, pname, shell-attribute, shell-pname, src }:
+  attribute, coq-attribute, no-rocq-yet, pname, shell-attribute, shell-pname, src }:
 with builtins; with lib;
 let
   mk-overlay = path: self: super:
@@ -27,10 +27,10 @@ let
       { inherit pname; version = "${src}"; } // args;
     in
       mapAttrs (n: ov: do-override (super.${n} or
-        (switch n [
+        (switch n (optional (!no-rocq-yet) [
           { case = attribute;       out = newRocqPkg pname {}; }
           { case = shell-attribute; out = newRocqPkg shell-pname {}; }
-        ] (newRocqPkg n ((super.${n}.mk or (_: {})) self))
+        ]) (newRocqPkg n ((super.${n}.mk or (_: {})) self))
       )) ov) (bundle.rocqPackages or {});
   coq-overrides =
     self: super:

--- a/template-config.nix
+++ b/template-config.nix
@@ -15,6 +15,10 @@
   ## (for instance "rocq-elpi" and "coq-elpi")
   # coq-attribute = "template";
 
+  ## Set this when the package has no rocqPackages version yet
+  ## (either in nixpkgs or in .nix/rocq-overlays)
+  # no-rock-yet = true;
+
   ## If you want to select a different attribute (to build from the local sources as well)
   ## when calling `nix-shell` and `nix-build` without the `--argstr job` argument
   # shell-attribute = "{{nix_name}}";


### PR DESCRIPTION
Add no-rocq-yet flag to avoid creating empty rocq package in that case